### PR TITLE
Fix undefined local variable or method error

### DIFF
--- a/lib/jekyll/tidy.rb
+++ b/lib/jekyll/tidy.rb
@@ -21,7 +21,7 @@ module Jekyll
     end
 
     def self.compress_output?
-      config["jekyll_tidy"] && config["jekyll_tidy"]["compress_html"]
+      jekyll_config["jekyll_tidy"] && jekyll_config["jekyll_tidy"]["compress_html"]
     end
 
     def self.output_clean(output, compress = false)
@@ -33,7 +33,7 @@ module Jekyll
     end
 
     def self.ignore_env?
-      Jekyll.env == (config["jekyll_tidy"] && config["jekyll_tidy"]["ignore_env"])
+      Jekyll.env == (jekyll_config["jekyll_tidy"] && jekyll_config["jekyll_tidy"]["ignore_env"])
     end
   end
 end


### PR DESCRIPTION
Fixes the following error 
```sh
path/to/ruby/2.2.0/gems/jekyll-tidy-0.2.1/lib/jekyll/tidy.rb:36:in `ignore_env?': undefined local variable or method `config' for Jekyll::Tidy:Module (NameError)
```