### PR TITLE
Package only the necessary files

### DIFF
--- a/jekyll-tidy.gemspec
+++ b/jekyll-tidy.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://www.apsis.io"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = Dir.glob("lib/**/*").concat(%w(LICENSE.txt README.md))
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Hello Wyatt,
I was checking out your cool plugin and realised that the gem bundles unnecessary files namely:
```
bin/console
bin/setup
.gitignore
.travis.yml
Rakefile
```

This change will limit to files in `lib/`, the license file and README document